### PR TITLE
try different encoding to fix read error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import subprocess
 
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open('README.md', encoding="utf8") as fh:
     long_description = fh.read().replace('](', '](https://raw.githubusercontent.com/FarisHijazi/PrivateGitHubCopilot/master/')
-with open('requirements.txt', 'r') as fh:
+with open('requirements.txt', encoding="utf8") as fh:
     rqeuirements = fh.readlines()
 
 version = subprocess.Popen('git describe --abbrev=0 --tags', shell=True, stdout=subprocess.PIPE).stdout.read().decode().strip().lstrip('v')


### PR DESCRIPTION
was getting this error:
 × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\lvana\AppData\Local\Temp\pip-req-build-e1y4flvp\setup.py", line 8, in <module>
          long_description = fh.read().replace('](', '](https://raw.githubusercontent.com/FarisHijazi/PrivateGitHubCopilot/master/')
        File "C:\ProgramData\Anaconda3\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 955: character maps to <undefined>
      [end of output]
      
changing your setup to specify utf-8 encoding fixed it.