### PR TITLE
Add GitHub auth endpoint (fixes FarisHijazi/PrivateGitHubCopilot)

### DIFF
--- a/PrivateGitHubCopilot/middleware.py
+++ b/PrivateGitHubCopilot/middleware.py
@@ -22,6 +22,15 @@ if os.name != 'nt':
 
 app = FastAPI()
 
+#Return fake token response to Copilot extension
+@app.get("/copilot_internal/v2/token")
+def get_copilot_token():
+    content = {'token': '1316850460', 'expires_at': 2600000000, 'refresh_in': 1800} #token value is just a random number
+    return JSONResponse(
+        status_code=200,
+        content=content
+    )
+
 
 @app.post("/v1/engines/codegen/completions")
 async def code_completion(body: dict):

--- a/README.md
+++ b/README.md
@@ -59,8 +59,12 @@ B. (optional) Test that the model is working by going to the "chat" tab and clic
         "debug.overrideProxyUrl": "http://localhost:8000",
     },
     ```
+    
+7. Update `~\.vscode\extensions\github.copilot-1.128.504\dist\extension.js` with the following:
+    - Replace `https://api.github.com/copilot_internal` with `http://127.0.0.1:5001/copilot_internal` (or your backend hosting your text-generation-webui server)
+    - replace `https://copilot-proxy.githubusercontent.com` with `http://127.0.0.1:5000` (or your backend hosting your text-generation-webui server)
 
-7. Run the proxy:
+8. Run the proxy:
 
     ```sh
     pip install git+https://github.com/FarisHijazi/PrivateGitHubCopilot
@@ -84,7 +88,7 @@ data: [DONE]
 
 </details>
 
-8. HAPPY CODING!
+9. HAPPY CODING!
 
     To test that the copilot extension is working, either type some code and hope for a completion
     or use the command pallet (`Ctrl+Shift+P`) and search for `GitHub Copilot: Open Completions Panel`


### PR DESCRIPTION
Add a new endpoint to allow github copilot vscode extension to initialize by pulling a fake token from PrivateGitHubCopilot server.